### PR TITLE
[performance] remove duplicate print sinks

### DIFF
--- a/flink-job/src/main/java/com/ververica/field/dynamicrules/RulesEvaluator.java
+++ b/flink-job/src/main/java/com/ververica/field/dynamicrules/RulesEvaluator.java
@@ -97,13 +97,10 @@ public class RulesEvaluator {
     DataStream<Rule> currentRules =
         ((SingleOutputStreamOperator<Alert>) alerts).getSideOutput(Descriptors.currentRulesSinkTag);
 
-    alerts.print().name("Alert STDOUT Sink");
     allRuleEvaluations.print().setParallelism(1).name("Rule Evaluation Sink");
 
     DataStream<String> alertsJson = AlertsSink.alertsStreamToJson(alerts);
     DataStream<String> currentRulesJson = CurrentRulesSink.rulesStreamToJson(currentRules);
-
-    currentRulesJson.print();
 
     int sinkParallelism = config.get(SINK_PARALLELISM);
 

--- a/flink-job/src/main/java/com/ververica/field/dynamicrules/functions/JsonSerializer.java
+++ b/flink-job/src/main/java/com/ververica/field/dynamicrules/functions/JsonSerializer.java
@@ -19,19 +19,20 @@
 package com.ververica.field.dynamicrules.functions;
 
 import com.ververica.field.dynamicrules.JsonMapper;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
 
-@Slf4j
 public class JsonSerializer<T> extends RichFlatMapFunction<T, String> {
 
   private JsonMapper<T> parser;
   private final Class<T> targetClass;
+  private final Logger log;
 
-  public JsonSerializer(Class<T> sourceClass) {
+  public JsonSerializer(Class<T> sourceClass, Logger log) {
     this.targetClass = sourceClass;
+    this.log = log;
   }
 
   @Override
@@ -43,6 +44,7 @@ public class JsonSerializer<T> extends RichFlatMapFunction<T, String> {
   @Override
   public void flatMap(T value, Collector<String> out) {
     try {
+      log.trace("{}", value);
       String serialized = parser.toString(value);
       out.collect(serialized);
     } catch (Exception e) {

--- a/flink-job/src/main/java/com/ververica/field/dynamicrules/sinks/AlertsSink.java
+++ b/flink-job/src/main/java/com/ververica/field/dynamicrules/sinks/AlertsSink.java
@@ -30,6 +30,7 @@ import com.ververica.field.dynamicrules.functions.JsonSerializer;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -38,6 +39,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.connectors.gcp.pubsub.PubSubSink;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011;
 
+@Slf4j
 public class AlertsSink {
 
   public static SinkFunction<String> createAlertsSink(Config config) throws IOException {
@@ -70,7 +72,7 @@ public class AlertsSink {
   }
 
   public static DataStream<String> alertsStreamToJson(DataStream<Alert> alerts) {
-    return alerts.flatMap(new JsonSerializer<>(Alert.class)).name("Alerts Serialization");
+    return alerts.flatMap(new JsonSerializer<>(Alert.class, log)).name("Alerts Serialization");
   }
 
   public enum Type {

--- a/flink-job/src/main/java/com/ververica/field/dynamicrules/sinks/CurrentRulesSink.java
+++ b/flink-job/src/main/java/com/ververica/field/dynamicrules/sinks/CurrentRulesSink.java
@@ -30,6 +30,7 @@ import com.ververica.field.dynamicrules.functions.JsonSerializer;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
@@ -37,6 +38,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.connectors.gcp.pubsub.PubSubSink;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011;
 
+@Slf4j
 public class CurrentRulesSink {
 
   public static SinkFunction<String> createRulesSink(Config config) throws IOException {
@@ -68,7 +70,7 @@ public class CurrentRulesSink {
   }
 
   public static DataStream<String> rulesStreamToJson(DataStream<Rule> alerts) {
-    return alerts.flatMap(new JsonSerializer<>(Rule.class)).name("Rules Serialization");
+    return alerts.flatMap(new JsonSerializer<>(Rule.class, log)).name("Rules Serialization");
   }
 
   public enum Type {

--- a/flink-job/src/main/resources/log4j2.properties
+++ b/flink-job/src/main/resources/log4j2.properties
@@ -5,3 +5,18 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %msg%n
+
+appender.briefStdout.type=Console
+appender.briefStdout.name=BRIEF_STDOUT
+appender.briefStdout.layout.type=PatternLayout
+appender.briefStdout.layout.pattern=%d{HH:mm:ss.SSS} [%replace{%t}{(\\w)(?: ->.+)? (\\(\\d+/\\d+\\))}{$1...$2}] %-5level %logger{1.} %msg%n
+
+#logger.alertsSinkLogger.name = com.ververica.field.dynamicrules.sinks.AlertsSink
+#logger.alertsSinkLogger.level = TRACE
+#logger.alertsSinkLogger.additivity = false
+#logger.alertsSinkLogger.appenderRef.console.ref=BRIEF_STDOUT
+
+#logger.currentRulesSinkLogger.name = com.ververica.field.dynamicrules.sinks.CurrentRulesSink
+#logger.currentRulesSinkLogger.level = TRACE
+#logger.currentRulesSinkLogger.additivity = false
+#logger.currentRulesSinkLogger.appenderRef.console.ref=BRIEF_STDOUT


### PR DESCRIPTION
- alerts can be printed (as JSON) by setting alerts-sink to STDOUT
- currentRulesJson can be printed by setting rules-export-sink to STDOUT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/lab-fraud-detection/2)
<!-- Reviewable:end -->
