### PR TITLE
[performance] make rule evaluations side output into trace logger

### DIFF
--- a/flink-job/src/main/java/com/ververica/field/dynamicrules/RulesEvaluator.java
+++ b/flink-job/src/main/java/com/ververica/field/dynamicrules/RulesEvaluator.java
@@ -88,16 +88,11 @@ public class RulesEvaluator {
             .uid("DynamicAlertFunction")
             .name("Dynamic Rule Evaluation Function");
 
-    DataStream<String> allRuleEvaluations =
-        ((SingleOutputStreamOperator<Alert>) alerts).getSideOutput(Descriptors.demoSinkTag);
-
     DataStream<Long> latency =
         ((SingleOutputStreamOperator<Alert>) alerts).getSideOutput(Descriptors.latencySinkTag);
 
     DataStream<Rule> currentRules =
         ((SingleOutputStreamOperator<Alert>) alerts).getSideOutput(Descriptors.currentRulesSinkTag);
-
-    allRuleEvaluations.print().setParallelism(1).name("Rule Evaluation Sink");
 
     DataStream<String> alertsJson = AlertsSink.alertsStreamToJson(alerts);
     DataStream<String> currentRulesJson = CurrentRulesSink.rulesStreamToJson(currentRules);
@@ -198,7 +193,6 @@ public class RulesEvaluator {
         new MapStateDescriptor<>(
             "rules", BasicTypeInfo.INT_TYPE_INFO, TypeInformation.of(Rule.class));
 
-    public static final OutputTag<String> demoSinkTag = new OutputTag<String>("demo-sink") {};
     public static final OutputTag<Long> latencySinkTag = new OutputTag<Long>("latency-sink") {};
     public static final OutputTag<Rule> currentRulesSinkTag =
         new OutputTag<Rule>("current-rules-sink") {};

--- a/flink-job/src/main/java/com/ververica/field/dynamicrules/functions/DynamicAlertFunction.java
+++ b/flink-job/src/main/java/com/ververica/field/dynamicrules/functions/DynamicAlertFunction.java
@@ -114,16 +114,8 @@ public class DynamicAlertFunction
       BigDecimal aggregateResult = aggregator.getLocalValue();
       boolean ruleResult = rule.apply(aggregateResult);
 
-      ctx.output(
-          Descriptors.demoSinkTag,
-          "Rule "
-              + rule.getRuleId()
-              + " | "
-              + value.getKey()
-              + " : "
-              + aggregateResult.toString()
-              + " -> "
-              + ruleResult);
+      log.trace(
+          "Rule {} | {} : {} -> {}", rule.getRuleId(), value.getKey(), aggregateResult, ruleResult);
 
       if (ruleResult) {
         if (COUNT_WITH_RESET.equals(rule.getAggregateFieldName())) {

--- a/flink-job/src/main/resources/log4j2.properties
+++ b/flink-job/src/main/resources/log4j2.properties
@@ -20,3 +20,8 @@ appender.briefStdout.layout.pattern=%d{HH:mm:ss.SSS} [%replace{%t}{(\\w)(?: ->.+
 #logger.currentRulesSinkLogger.level = TRACE
 #logger.currentRulesSinkLogger.additivity = false
 #logger.currentRulesSinkLogger.appenderRef.console.ref=BRIEF_STDOUT
+
+#logger.ruleEvaluationLogger.name = com.ververica.field.dynamicrules.functions.DynamicAlertFunction
+#logger.ruleEvaluationLogger.level = TRACE
+#logger.ruleEvaluationLogger.additivity = false
+#logger.ruleEvaluationLogger.appenderRef.console.ref=BRIEF_STDOUT


### PR DESCRIPTION
In the current state, this stream is only needed for debugging / showing every
action in the console which can be better achieved by enabling a logger. If the
transaction throughput increases, this would have been a bottleneck.

log4j2.properties speficies a new logger for getting the output back in a
similar fashion with added thread info.

Note that this is based on #2 and builds on top of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/lab-fraud-detection/3)
<!-- Reviewable:end -->
