### PR TITLE
allow specifying the default parallelism to use

### DIFF
--- a/flink-job/src/main/java/com/ververica/field/config/Parameters.java
+++ b/flink-job/src/main/java/com/ververica/field/config/Parameters.java
@@ -83,6 +83,7 @@ public class Parameters {
   public static final Param<Integer> SOCKET_PORT = Param.integer("pubsub-rules-export", 9999);
 
   // General:
+  public static final Param<Integer> DEFAULT_PARALLELISM = Param.integer("parallelism", -1);
   //    source/sink types: kafka / pubsub / socket
   public static final Param<String> RULES_SOURCE = Param.string("rules-source", "SOCKET");
   public static final Param<String> TRANSACTIONS_SOURCE = Param.string("data-source", "GENERATOR");
@@ -147,6 +148,7 @@ public class Parameters {
 
   public static final List<Param<Integer>> INT_PARAMS =
       Arrays.asList(
+          DEFAULT_PARALLELISM,
           KAFKA_PORT,
           SOCKET_PORT,
           RECORDS_PER_SECOND,

--- a/flink-job/src/main/java/com/ververica/field/dynamicrules/RulesEvaluator.java
+++ b/flink-job/src/main/java/com/ververica/field/dynamicrules/RulesEvaluator.java
@@ -19,6 +19,7 @@
 package com.ververica.field.dynamicrules;
 
 import static com.ververica.field.config.Parameters.CHECKPOINT_INTERVAL;
+import static com.ververica.field.config.Parameters.DEFAULT_PARALLELISM;
 import static com.ververica.field.config.Parameters.LOCAL_EXECUTION;
 import static com.ververica.field.config.Parameters.LOCAL_MODE_DISABLE_WEB_UI;
 import static com.ververica.field.config.Parameters.MIN_PAUSE_BETWEEN_CHECKPOINTS;
@@ -165,6 +166,11 @@ public class RulesEvaluator {
       env.setRestartStrategy(
           RestartStrategies.fixedDelayRestart(
               10, org.apache.flink.api.common.time.Time.of(10, TimeUnit.SECONDS)));
+    }
+
+    final Integer parallelism = config.get(DEFAULT_PARALLELISM);
+    if (parallelism > 0) {
+      env.setParallelism(parallelism);
     }
 
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);


### PR DESCRIPTION
This is mostly useful for local setups where you can otherwise not configure it. You can now use this, for example, to start with a parallelism of 4 by default:

```
--parallelism 4
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/lab-fraud-detection/4)
<!-- Reviewable:end -->
